### PR TITLE
Adjust the wording for unauthorized access

### DIFF
--- a/views/unauthorized.jade
+++ b/views/unauthorized.jade
@@ -7,7 +7,7 @@ block content
     code @mozilla.com
     |  address
   p
-    | We apologizes the inconvenience, if you is a Mozilla-employee please
+    | We apologize for the inconvenience, if you are a Mozilla-employee please
     | login with another address. Otherwise, help us authorize access for
     | community members with reasonable commit level access, i.e. file a bug
     | to get this fixed.


### PR DESCRIPTION
This tweak fixes the wording for unauthorized access presented in the front end.

Per this dialogue:

![accessmozonly](https://cloud.githubusercontent.com/assets/3660661/7663165/eab3f696-fb33-11e4-8eea-7f2e81ae3795.jpg)

Adding @jonasfj for review and/or closing without merge if the code base is going away :)
